### PR TITLE
Cache for shrink-to-fit width

### DIFF
--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -299,6 +299,10 @@ public:
 	/// @return Time until next update is expected.
 	double GetNextUpdateDelay() const;
 
+	/// Get current frame number. Frame number is incremented every time Update() is called.
+	/// @return Current frame number.
+	int GetFrameNumber() const;
+
 protected:
 	void Release() override;
 
@@ -307,6 +311,7 @@ private:
 	Vector2i dimensions;
 	float density_independent_pixel_ratio;
 	String documents_base_tag = "body";
+	int frame_number = 0;
 
 	SmallUnorderedSet<String> active_themes;
 

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -599,6 +599,19 @@ public:
 	/// Return the computed values of the element's properties. These values are updated as appropriate on every Context::Update.
 	const ComputedValues& GetComputedValues() const;
 
+	/// Set cached shrink to fit width value.
+	/// @param[in] width The width to cache.
+	/// @param[in] container_size The size of the container (used as cache key).
+	void SetCachedShrinkToFitWidth(float width, Vector2f container_size);
+
+	/// Get cached shrink to fit width value.
+	/// Note: The cache is invalidated on each frame number increment. Values from
+	/// the previous frame will never be returned.
+	/// @param[out] width The cached width.
+	/// @param[in] container_size The size of the container (used as cache key).
+	/// @return True if a cached value was found.
+	bool GetCachedShrinkToFitWidth(float& width, Vector2f container_size) const;
+
 protected:
 	void Update(float dp_ratio, Vector2f vp_dimensions);
 	void Render();
@@ -787,6 +800,10 @@ private:
 	ElementAnimationList animations;
 
 	ElementMeta* meta;
+
+	// Shrink to fit cache.
+	std::unordered_map<Vector2f, float, Vector2fHash> cached_shrink_to_fit_widths;
+	int cached_shrink_to_fit_widths_frame_number = 0;
 
 	friend class Rml::Context;
 	friend class Rml::ElementStyle;

--- a/Include/RmlUi/Core/Math.h
+++ b/Include/RmlUi/Core/Math.h
@@ -43,6 +43,10 @@ class Vector2;
 using Vector2f = Vector2<float>;
 using Vector2i = Vector2<int>;
 
+struct Vector2fHash {
+	auto operator()(const Vector2f& v) const noexcept -> std::size_t;
+};
+
 namespace Math {
 
 	constexpr float RMLUI_PI = 3.141592653f;

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -179,6 +179,7 @@ bool Context::Update()
 	RMLUI_ZoneScoped;
 
 	next_update_timeout = std::numeric_limits<double>::infinity();
+	frame_number++;
 
 	if (scroll_controller->Update(mouse_position, density_independent_pixel_ratio))
 		RequestNextUpdate(0);
@@ -1409,6 +1410,11 @@ void Context::RequestNextUpdate(double delay)
 double Context::GetNextUpdateDelay() const
 {
 	return next_update_timeout;
+}
+
+int Context::GetFrameNumber() const
+{
+	return frame_number;
 }
 
 } // namespace Rml

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -2897,4 +2897,31 @@ void Element::DirtyFontFaceRecursive()
 		GetChild(i)->DirtyFontFaceRecursive();
 }
 
+void Element::SetCachedShrinkToFitWidth(float width, Vector2f container_size)
+{
+	int frame_number = GetContext()->GetFrameNumber();
+	if (cached_shrink_to_fit_widths_frame_number != frame_number)
+	{
+		cached_shrink_to_fit_widths.clear();
+		cached_shrink_to_fit_widths_frame_number = frame_number;
+	}
+	cached_shrink_to_fit_widths[container_size] = width;
+}
+
+bool Element::GetCachedShrinkToFitWidth(float& width, Vector2f container_size) const
+{
+	int frame_number = GetContext()->GetFrameNumber();
+	if (cached_shrink_to_fit_widths_frame_number != frame_number)
+	{
+		return false;
+	}
+	auto it = cached_shrink_to_fit_widths.find(container_size);
+	if (it == cached_shrink_to_fit_widths.end())
+	{
+		return false;
+	}
+	width = it->second;
+	return true;
+}
+
 } // namespace Rml

--- a/Source/Core/Layout/LayoutDetails.cpp
+++ b/Source/Core/Layout/LayoutDetails.cpp
@@ -248,6 +248,12 @@ float LayoutDetails::GetShrinkToFitWidth(Element* element, Vector2f containing_b
 {
 	RMLUI_ASSERT(element);
 
+	float cached_shrink_to_fit_width;
+	if (element->GetCachedShrinkToFitWidth(cached_shrink_to_fit_width, containing_block))
+	{
+		return cached_shrink_to_fit_width;
+	}
+
 	// @performance Can we lay out the elements directly using a fit-content size mode, instead of fetching the
 	// shrink-to-fit width first? Use a non-definite placeholder for the box content width, and available width as a
 	// maximum constraint.
@@ -260,6 +266,7 @@ float LayoutDetails::GetShrinkToFitWidth(Element* element, Vector2f containing_b
 	const Style::Display display = element->GetDisplay();
 	if (display == Style::Display::Table || display == Style::Display::InlineTable)
 	{
+		element->SetCachedShrinkToFitWidth(0.f, containing_block);
 		return 0.f;
 	}
 
@@ -283,6 +290,7 @@ float LayoutDetails::GetShrinkToFitWidth(Element* element, Vector2f containing_b
 			Math::Max(0.f, containing_block.x - box.GetSizeAcross(BoxDirection::Horizontal, BoxArea::Margin, BoxArea::Padding));
 		shrink_to_fit_width = Math::Min(shrink_to_fit_width, available_width);
 	}
+	element->SetCachedShrinkToFitWidth(shrink_to_fit_width, containing_block);
 	return shrink_to_fit_width;
 }
 

--- a/Source/Core/Math.cpp
+++ b/Source/Core/Math.cpp
@@ -280,4 +280,10 @@ namespace Math {
 	}
 
 } // namespace Math
+
+auto Vector2fHash::operator()(const Vector2f& v) const noexcept -> size_t
+{
+	return std::hash<float>()(v.x) ^ std::hash<float>()(v.y);
+}
+
 } // namespace Rml


### PR DESCRIPTION
Reduces amortized complexity of nested flex layout from O(N^2) to O(N).